### PR TITLE
Refactoring of priority rules

### DIFF
--- a/src/main/java/com/redhat/emergency/response/incident/priority/MessageConsumerVerticle.java
+++ b/src/main/java/com/redhat/emergency/response/incident/priority/MessageConsumerVerticle.java
@@ -78,7 +78,7 @@ public class MessageConsumerVerticle extends AbstractVerticle {
             if (INCIDENT_ASSIGNMENT_EVENT.equals(messageType)) {
                 if (event.getString("incidentId") == null || event.getBoolean("assignment") == null ||
                         event.getDouble("lat") == null || event.getDouble("lon") == null) {
-                    log.warn("Message of type '" + "' has unexpected structure: " + event.toString());
+                    log.warn("Message of type '" + messageType + "' has unexpected structure: " + event.toString());
                     return;
                 }
                 String incidentId = event.getString("incidentId");
@@ -87,16 +87,16 @@ public class MessageConsumerVerticle extends AbstractVerticle {
 
                 vertx.eventBus().send("incident-assignment-event", event);
             } else if (INCIDENT_REPORTED_EVENT.equals(messageType)) {
-                if (event.getString("incidentId") == null ||
+                if (event.getString("id") == null ||
                         event.getDouble("lat") == null || event.getDouble("lon") == null) {
-                    log.warn("Message of type '" + "' has unexpected structure: " + event.toString());
+                    log.warn("Message of type '" + messageType + "' has unexpected structure: " + event.toString());
                     return;
                 }
                 JsonObject payload = new JsonObject()
                         .put("incidentId", event.getString("id"))
                         .put("assigment", false)
-                        .put("lat", event.getDouble("lat").toString())
-                        .put("lon", event.getDouble("lon").toString());
+                        .put("lat", event.getDouble("lat"))
+                        .put("lon", event.getDouble("lon"));
 
                 String incidentId = payload.getString("incidentId");
                 log.debug("Consumed '" + messageType + "' message for incident '" + incidentId + "'. Topic: " + msg.topic()

--- a/src/main/java/com/redhat/emergency/response/incident/priority/RulesVerticle.java
+++ b/src/main/java/com/redhat/emergency/response/incident/priority/RulesVerticle.java
@@ -125,7 +125,7 @@ public class RulesVerticle extends AbstractVerticle {
         if (row == null) {
             average = 0.0;
         } else {
-            average = ((AveragePriority)row.get("averagePriority")).getAveragePriority();
+            average = ((AveragePriority)row.get("averagePriority")).getResult();
         }
 
         results = ksession.getQueryResults("incidents");

--- a/src/main/java/com/redhat/emergency/response/incident/priority/rules/model/AveragePriority.java
+++ b/src/main/java/com/redhat/emergency/response/incident/priority/rules/model/AveragePriority.java
@@ -2,28 +2,43 @@ package com.redhat.emergency.response.incident.priority.rules.model;
 
 public class AveragePriority {
 
-    private Double averagePriority;
+    private int count;
 
-    private boolean needsEvaluation;
+    private double total;
 
     public AveragePriority() {
-        averagePriority = 0.0;
-        needsEvaluation = false;
+        total = 0.0;
     }
 
-    public Double getAveragePriority() {
-        return averagePriority;
+    public void accumulate(Number value) {
+        if (value != null) {
+            this.total += value.doubleValue();
+        }
     }
 
-    public void setAveragePriority(Double averagePriority) {
-        this.averagePriority = averagePriority;
+    public void reverse(Number value) {
+        if (value != null) {
+            this.count--;
+            this.total -= value.doubleValue();
+        }
+        if (count == 0) {
+            total = 0.0;
+        }
     }
 
-    public boolean isNeedsEvaluation() {
-        return needsEvaluation;
+    public void add() {
+        this.count++;
     }
 
-    public void setNeedsEvaluation(boolean needsEvaluation) {
-        this.needsEvaluation = needsEvaluation;
+    public void retract() {
+        this.count--;
+    }
+
+    public Double getResult() {
+        if (count == 0) {
+            return 0.0;
+        } else {
+            return total / count;
+        }
     }
 }

--- a/src/main/resources/com/redhat/emergency/response/incident/priority/rules/priority_rules.drl
+++ b/src/main/resources/com/redhat/emergency/response/incident/priority/rules/priority_rules.drl
@@ -23,9 +23,13 @@ rule "Create incident priority fact when incident cannot be assigned"
 when
     $e: IncidentAssignmentEvent( $i: incident, assigned == false )
     not ( IncidentPriority( incident == $i ) )
+    $a: AveragePriority()
 then
     logger.debug($i + " : " + drools.getRule().getName());
     insert( new IncidentPriority($i, $e.getLat(), $e.getLon()) );
+    modify ( $a ) {
+      add()
+    }
 end
 
 rule "Update priority zone fact for an adjusted zone"
@@ -141,7 +145,7 @@ then
         setPriority( $p.getPriority() + 1 )
     }
     modify ( $a ) {
-        setNeedsEvaluation(true)
+        accumulate(1)
     }
     retract( $e );
     logger.debug($i + " : Priority = " + $p.getPriority());
@@ -155,36 +159,11 @@ when
     $a: AveragePriority()
 then
     logger.debug($i + " : " + drools.getRule().getName());
+    modify ( $a ) {
+        reverse( $p.getPriority() )
+    }
     retract ( $p );
     retract ( $e );
-    modify ( $a ) {
-        setNeedsEvaluation(true)
-    }
-end
-
-rule "Average Priority"
-when
-    $a: AveragePriority( needsEvaluation == true )
-    IncidentPriority()
-    accumulate( IncidentPriority( $p: priority );  $avg: average( $p ) )
-then
-    modify ( $a ) {
-        setNeedsEvaluation(false),
-        setAveragePriority($avg)
-    }
-    logger.debug("Average Priority: " + $a.getAveragePriority());
-end
-
-rule "Average Priority when no IncidentPriority"
-when
-    $a: AveragePriority( needsEvaluation == true )
-    not ( IncidentPriority() )
-then
-    modify ( $a ) {
-        setNeedsEvaluation(false),
-        setAveragePriority(0.0)
-    }
-    logger.debug("Average Priority: " + $a.getAveragePriority());
 end
 
 query "incidentPriority" (String i)

--- a/src/test/java/com/redhat/emergency/response/incident/priority/rules/PriorityRulesTest.java
+++ b/src/test/java/com/redhat/emergency/response/incident/priority/rules/PriorityRulesTest.java
@@ -52,7 +52,7 @@ public class PriorityRulesTest {
     public void setupTest() {
         session = kieBase.newKieSession();
         Logger logger = LoggerFactory.getLogger("PriorityRules");
-        Integer priorityZoneUpsurge = Integer.valueOf(50);
+        Integer priorityZoneUpsurge = 50;
         session.setGlobal("logger", logger);
         session.setGlobal("priorityZoneUpsurge", priorityZoneUpsurge);
     }
@@ -109,7 +109,7 @@ public class PriorityRulesTest {
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(1.0));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(1.0));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(1));
     }
@@ -118,13 +118,15 @@ public class PriorityRulesTest {
     public void testAveragePriority2() {
         session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
         session.fireAllRules();
+        session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
+        session.fireAllRules();
         QueryResults results = session.getQueryResults("averagePriority");
         assertThat(results.size(), equalTo(1));
         QueryResultsRow row = StreamSupport.stream(results.spliterator(), false).findFirst().orElse(null);
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(1.0));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(2.0));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(1));
     }
@@ -141,7 +143,7 @@ public class PriorityRulesTest {
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(0.0));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(0.0));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(0));
     }
@@ -150,6 +152,25 @@ public class PriorityRulesTest {
     public void testAveragePriority4() {
         session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
         session.fireAllRules();
+        session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
+        session.fireAllRules();
+        session.insert(new IncidentAssignmentEvent("incident123", true, BigDecimal.ZERO, BigDecimal.ZERO));
+        session.fireAllRules();
+        QueryResults results = session.getQueryResults("averagePriority");
+        assertThat(results.size(), equalTo(1));
+        QueryResultsRow row = StreamSupport.stream(results.spliterator(), false).findFirst().orElse(null);
+        assertThat(row, notNullValue());
+        assertThat(row.get("averagePriority"), notNullValue());
+        assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(0.0));
+        QueryResults incidents = session.getQueryResults("incidents");
+        assertThat(incidents.size(), equalTo(0));
+    }
+
+    @Test
+    public void testAveragePriority5() {
+        session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
+        session.fireAllRules();
         session.insert(new IncidentAssignmentEvent("incident456", false, BigDecimal.ZERO, BigDecimal.ZERO));
         session.fireAllRules();
         QueryResults results = session.getQueryResults("averagePriority");
@@ -158,13 +179,13 @@ public class PriorityRulesTest {
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(1.0));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(1.0));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(2));
     }
 
     @Test
-    public void testAveragePriority5() {
+    public void testAveragePriority6() {
         session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
         session.fireAllRules();
         session.insert(new IncidentAssignmentEvent("incident456", false, BigDecimal.ZERO, BigDecimal.ZERO));
@@ -177,13 +198,13 @@ public class PriorityRulesTest {
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(1.5));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(1.5));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(2));
     }
 
     @Test
-    public void testAveragePriority6() {
+    public void testAveragePriority7() {
         session.insert(new IncidentAssignmentEvent("incident123", false, BigDecimal.ZERO, BigDecimal.ZERO));
         session.fireAllRules();
         session.insert(new IncidentAssignmentEvent("incident456", false, BigDecimal.ZERO, BigDecimal.ZERO));
@@ -198,20 +219,20 @@ public class PriorityRulesTest {
         assertThat(row, notNullValue());
         assertThat(row.get("averagePriority"), notNullValue());
         assertThat(row.get("averagePriority"), is(instanceOf(AveragePriority.class)));
-        assertThat(((AveragePriority)row.get("averagePriority")).getAveragePriority(), equalTo(2.0));
+        assertThat(((AveragePriority)row.get("averagePriority")).getResult(), equalTo(2.0));
         QueryResults incidents = session.getQueryResults("incidents");
         assertThat(incidents.size(), equalTo(1));
     }
 
     @Test
     public void testPriorityZoneAddedBeforeIncident() {
-        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone));
         session.fireAllRules();
         PriorityZone priorityZone2 = new PriorityZone("pz1234", new BigDecimal(0), new BigDecimal(0), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone2));
         session.fireAllRules();
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false,  new BigDecimal(34.19439), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false,  new BigDecimal("34.19439"), new BigDecimal("-77.81453")));
         session.fireAllRules();
         QueryResults results = session.getQueryResults("incidentPriority", "3a64e1f5-848c-42af-bc8c-abce650d4e46");
         assertThat(results.size(), equalTo(1));
@@ -225,13 +246,13 @@ public class PriorityRulesTest {
 
     @Test
     public void testPriorityZoneAddedAfterIncident() {
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e44", false, new BigDecimal(0), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e44", false, new BigDecimal(0), new BigDecimal("-77.81453")));
         session.fireAllRules();
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal(34.19439), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal("34.19439"), new BigDecimal("-77.81453")));
         session.fireAllRules();
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e45", false, new BigDecimal(0), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e45", false, new BigDecimal(0), new BigDecimal("-77.81453")));
         session.fireAllRules();
-        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone));
         session.fireAllRules();
         QueryResults results = session.getQueryResults("incidentPriority", "3a64e1f5-848c-42af-bc8c-abce650d4e46");
@@ -245,10 +266,10 @@ public class PriorityRulesTest {
 
     @Test
     public void testPriorityZoneClearEvent() {
-        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone));
         session.fireAllRules();
-        PriorityZone priorityZone2 = new PriorityZone("pz1234", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone2 = new PriorityZone("pz1234", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone2));
         session.fireAllRules();
         session.insert(new PriorityZoneClearEvent());
@@ -259,10 +280,10 @@ public class PriorityRulesTest {
 
     @Test
     public void testPriorityZoneDeEscalation() {
-        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone));
         session.fireAllRules();
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal(34.19439), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal("34.19439"), new BigDecimal("-77.81453")));
         session.fireAllRules();
 
         //make sure incident gets escalated
@@ -288,15 +309,15 @@ public class PriorityRulesTest {
     @Test
     public void testSkipDeEscalationWhenInMultiplePriorityZones() {
         //Add two priority zones in the same spot
-        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone = new PriorityZone("pz123", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone));
         session.fireAllRules();
-        PriorityZone priorityZone2 = new PriorityZone("pz1234", new BigDecimal(34.19439), new BigDecimal(-77.81453), new BigDecimal(6));
+        PriorityZone priorityZone2 = new PriorityZone("pz1234", new BigDecimal("34.19439"), new BigDecimal("-77.81453"), new BigDecimal(6));
         session.insert(new PriorityZoneApplicationEvent(priorityZone2));
         session.fireAllRules();
 
         //Add an incident that falls in both
-        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal(34.19439), new BigDecimal(-77.81453)));
+        session.insert(new IncidentAssignmentEvent("3a64e1f5-848c-42af-bc8c-abce650d4e46", false, new BigDecimal("34.19439"), new BigDecimal("-77.81453")));
         session.fireAllRules();
 
         //make sure incident gets escalated


### PR DESCRIPTION
Accumulate function to calculate the average priority does not scale well. Refactoring gets rid of accumulate function and calculates the average when needed.